### PR TITLE
https://inaniwaudon.github.io/genkotsu?gregear にアクセスすると`gif.js`が読み込めない

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -114,7 +114,7 @@ const Index = () => {
             )}
             <Script async src="https://platform.twitter.com/widgets.js" />
           </SnsParagraph>
-          <Script src="./gif.js" />
+          <Script src="/genkotsu/gif.js" />
         </Footer>
       </Main>
     </>


### PR DESCRIPTION
- Twitterに拡散されているURL https://inaniwaudon.github.io/genkotsu?gregear からアクセスすると`gif.ls`が読み込めなくなる
    - <img width="356" alt="image" src="https://user-images.githubusercontent.com/612043/235730740-6a5d89d0-cba4-411c-a280-cce88c5a1433.png">
    - Twitter検索: https://twitter.com/search?q=https%3A%2F%2Finaniwaudon.github.io%2Fgenkotsu%3Fgregear&src=typed_query&f=live
    - https://inaniwaudon.github.io/genkotsu/ ならOK 🙆‍♀️ 
- https://inaniwaudon.github.io/genkotsu?gregear を利用するのをやめるべきかもしれないが、`gif.js`のパス指定を修正した