### PR TITLE
Canvas描画前にフォントの読み込みを待つ

### DIFF
--- a/src/components/GenkotsuDrawer.tsx
+++ b/src/components/GenkotsuDrawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useTransition } from "react";
 import styled from "styled-components";
-import { createGif, drawGenkotsu, drawerHeight, drawerWidth } from "@/draw";
+import { createGif, drawGenkotsu, drawerHeight, drawerWidth } from "@/libs/draw";
 
 const maxWidth = 400 * (16 / 9);
 
@@ -55,7 +55,9 @@ const GenkotsuDrawer = ({ text }: GenkotsuDrawerProps) => {
         if (!context) {
           return;
         }
-        drawGenkotsu(text, drawerWidth, drawerHeight, context);
+        document.fonts.ready.then(() =>
+          drawGenkotsu(text, drawerWidth, drawerHeight, context)
+        )
       }
     });
   }, [text]);

--- a/src/libs/draw.ts
+++ b/src/libs/draw.ts
@@ -1,4 +1,4 @@
-import { keiFont } from "./styles/localFonts";
+import { keiFont } from "@/styles/localFonts";
 
 const fontSize = 230;
 const descender = 0.88;
@@ -15,6 +15,7 @@ export const drawText = (
   context.fillStyle = "#000";
   context.strokeStyle = strokeStyle;
   context.lineWidth = 6;
+  // `var(--kei-font)` is not worked somehow
   context.font = `${fontSize}px ${keiFont.style.fontFamily}`;
   context.textAlign = "center";
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import Script from "next/script";
 import Head from "next/head";
 import styled from "styled-components";
 import GenkotsuDrawer from "@/components/GenkotsuDrawer";
-import { keiFont } from "@/styles/localFonts";
 
 const Main = styled.main`
   font-family: sans-serif;
@@ -13,7 +12,7 @@ const Main = styled.main`
 const Input = styled.input`
   max-width: 100%;
   font-size: 48px;
-  font-family: ${keiFont.style.fontFamily};
+  font-family: var(--kei-font);
   margin-bottom: 24px;
   border-top: none;
   border-right: none;

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -1,9 +1,14 @@
 import { createGlobalStyle } from 'styled-components'
+import { keiFont } from './localFonts'
 
 export const GlobalStyle = createGlobalStyle`
   html,
   body {
     margin: 0;
     padding: 0;
+  }
+
+  :root {
+    --kei-font: ${keiFont.style.fontFamily};
   }
 `

--- a/src/styles/localFonts.ts
+++ b/src/styles/localFonts.ts
@@ -1,7 +1,6 @@
 import localFont from 'next/font/local'
 
 export const keiFont = localFont({
-  src: '../pages/keifont.ttf',
-  variable: '--keifont',
+  src: '../assets/keifont.ttf',
   display: 'swap',
 })


### PR DESCRIPTION
`document.fonts.ready` でフォントの読み込みを待つようにしました。

https://github.com/inaniwaudon/genkotsu/issues/6#issuecomment-1531958436 の問題は治ったように見えますが、念の為確かめてもらえるとありがたいです。

`yarn dev --port 3000` 及び `yarn build && yarn start --port 3001` の環境で確認しました。ハードリロードでもフォントがちゃんと適用されています。