### PR TITLE
trailingSlash を true に

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,29 +1,30 @@
-const path = require('path')
-const CopyPlugin = require('copy-webpack-plugin')
+const path = require("path");
+const CopyPlugin = require("copy-webpack-plugin");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  basePath: process.env.GITHUB_ACTIONS ? '/genkotsu' : '',
+  basePath: process.env.GITHUB_ACTIONS ? "/genkotsu" : "",
   webpack: (config) => {
-    const nextPublicDirPath = path.resolve(__dirname, 'public')
+    const nextPublicDirPath = path.resolve(__dirname, "public");
     config.plugins.push(
       new CopyPlugin({
-          patterns: [
-            {
-                from: './node_modules/gif.js/dist/gif.worker.js',
-                to: nextPublicDirPath
-            },
-            {
-                from: './node_modules/gif.js/dist/gif.worker.js.map',
-                to: nextPublicDirPath,
-            },
-          ],
+        patterns: [
+          {
+            from: "./node_modules/gif.js/dist/gif.worker.js",
+            to: nextPublicDirPath,
+          },
+          {
+            from: "./node_modules/gif.js/dist/gif.worker.js.map",
+            to: nextPublicDirPath,
+          },
+        ],
       })
-    )
+    );
 
-    return config
+    return config;
   },
+  trailingSlash: true,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
`https://inaniwaudon.github.io/genkotsu?hogehoge` にアクセスした際に gif.worker.js の読み込みに失敗していたので、next.config.js を `trailingSlash: true` と設定し、`genkotsu/?hogehoge` に転送されるようにする